### PR TITLE
Make the field Provider omitempty in Insurance

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Shippo API Golang Wrapper
 
-Documentation: https://godoc.org/github.com/coldbrewcloud/go-shippo/client
+Documentation: https://godoc.org/github.com/courtyard-nft/go-shippo/client
 
 ## Examples
 ```go
@@ -12,9 +12,9 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/coldbrewcloud/go-shippo"
-	"github.com/coldbrewcloud/go-shippo/client"
-	"github.com/coldbrewcloud/go-shippo/models"
+	"github.com/courtyard-nft/go-shippo"
+	"github.com/courtyard-nft/go-shippo/client"
+	"github.com/courtyard-nft/go-shippo/models"
 )
 
 func main() {
@@ -122,4 +122,4 @@ func dump(v interface{}) string {
 
 ```
 
-See [more examples](https://github.com/coldbrewcloud/go-shippo/tree/master/_examples).
+See [more examples](https://github.com/courtyard-nft/go-shippo/tree/master/_examples).

--- a/_examples/address_validation/main.go
+++ b/_examples/address_validation/main.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/coldbrewcloud/go-shippo"
-	"github.com/coldbrewcloud/go-shippo/models"
+	"github.com/courtyard-nft/go-shippo"
+	"github.com/courtyard-nft/go-shippo/models"
 )
 
 var (

--- a/_examples/carrier_accounts/main.go
+++ b/_examples/carrier_accounts/main.go
@@ -5,9 +5,9 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/coldbrewcloud/go-shippo"
-	"github.com/coldbrewcloud/go-shippo/client"
-	"github.com/coldbrewcloud/go-shippo/models"
+	"github.com/courtyard-nft/go-shippo"
+	"github.com/courtyard-nft/go-shippo/client"
+	"github.com/courtyard-nft/go-shippo/models"
 )
 
 var (

--- a/_examples/first_shipment/main.go
+++ b/_examples/first_shipment/main.go
@@ -6,9 +6,9 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/coldbrewcloud/go-shippo"
-	"github.com/coldbrewcloud/go-shippo/client"
-	"github.com/coldbrewcloud/go-shippo/models"
+	"github.com/courtyard-nft/go-shippo"
+	"github.com/courtyard-nft/go-shippo/client"
+	"github.com/courtyard-nft/go-shippo/models"
 )
 
 func main() {

--- a/client/address.go
+++ b/client/address.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"net/http"
 
-	"github.com/coldbrewcloud/go-shippo/models"
+	"github.com/courtyard-nft/go-shippo/models"
 )
 
 // CreateAddress creates a new address object.
@@ -22,7 +22,7 @@ func (c *Client) CreateAddress(input *models.AddressInput) (*models.Address, err
 // RetrieveAddress retrieves an existing address by object id.
 func (c *Client) RetrieveAddress(objectID string) (*models.Address, error) {
 	if objectID == "" {
-		return nil, errors.New("Empty object ID")
+		return nil, errors.New("empty object ID")
 	}
 
 	output := &models.Address{}

--- a/client/batch.go
+++ b/client/batch.go
@@ -6,7 +6,7 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/coldbrewcloud/go-shippo/models"
+	"github.com/courtyard-nft/go-shippo/models"
 )
 
 // RetrieveBatch retrieves an existing batch. BatchShipments are displayed 100 at a time.
@@ -14,7 +14,7 @@ import (
 // You can also filter based on BatchShipment status using objectResultsFilter parameter
 func (c *Client) RetrieveBatch(objectID string, page uint, objectResultsFilter string) (*models.Batch, error) {
 	if objectID == "" {
-		return nil, errors.New("Empty object ID")
+		return nil, errors.New("empty object ID")
 	}
 
 	url := "/batches/" + objectID
@@ -37,7 +37,7 @@ func (c *Client) RetrieveBatch(objectID string, page uint, objectResultsFilter s
 // AddBatchShipmentsToBatch adds batch shipment(s) to an existing Batch.
 func (c *Client) AddBatchShipmentsToBatch(objectID string, batchShipments []*models.BatchShipmentInput) (*models.Batch, error) {
 	if objectID == "" {
-		return nil, errors.New("Empty object ID")
+		return nil, errors.New("empty object ID")
 	}
 	if batchShipments == nil {
 		return nil, errors.New("nil batch shipments")
@@ -51,7 +51,7 @@ func (c *Client) AddBatchShipmentsToBatch(objectID string, batchShipments []*mod
 // RemoveBatchShipmentsFromBatch removes batch shipment(s) from an existing Batch.
 func (c *Client) RemoveBatchShipmentsFromBatch(objectID string, batchShipmentIDs []string) (*models.Batch, error) {
 	if objectID == "" {
-		return nil, errors.New("Empty object ID")
+		return nil, errors.New("empty object ID")
 	}
 	if batchShipmentIDs == nil {
 		return nil, errors.New("nil batch shipment IDs")
@@ -68,7 +68,7 @@ func (c *Client) RemoveBatchShipmentsFromBatch(objectID string, batchShipmentIDs
 // and you will receive a batch_purchased webhook indicating that the batch has been purchased.
 func (c *Client) PurchaseBatch(objectID string) (*models.Batch, error) {
 	if objectID == "" {
-		return nil, errors.New("Empty object ID")
+		return nil, errors.New("empty object ID")
 	}
 
 	output := &models.Batch{}

--- a/client/carrier_account.go
+++ b/client/carrier_account.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"net/http"
 
-	"github.com/coldbrewcloud/go-shippo/models"
+	"github.com/courtyard-nft/go-shippo/models"
 )
 
 // CreateCarrierAccount creates a new carrier account object.
@@ -22,7 +22,7 @@ func (c *Client) CreateCarrierAccount(input *models.CarrierAccountInput) (*model
 // RetrieveCarrierAccount retrieves an existing carrier account by object id.
 func (c *Client) RetrieveCarrierAccount(objectID string) (*models.CarrierAccount, error) {
 	if objectID == "" {
-		return nil, errors.New("Empty object ID")
+		return nil, errors.New("empty object ID")
 	}
 
 	output := &models.CarrierAccount{}
@@ -49,7 +49,7 @@ func (c *Client) ListAllCarrierAccounts() ([]*models.CarrierAccount, error) {
 // AccountID and Carrier cannot be updated because they form the unique identifier together.
 func (c *Client) UpdateCarrierAccount(objectID string, input *models.CarrierAccountInput) (*models.CarrierAccount, error) {
 	if objectID == "" {
-		return nil, errors.New("Empty object ID")
+		return nil, errors.New("empty object ID")
 	}
 	if input == nil {
 		return nil, errors.New("nil input")

--- a/client/client.go
+++ b/client/client.go
@@ -10,8 +10,8 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/coldbrewcloud/go-shippo/errors"
-	"github.com/coldbrewcloud/go-shippo/models"
+	"github.com/courtyard-nft/go-shippo/errors"
+	"github.com/courtyard-nft/go-shippo/models"
 )
 
 const (
@@ -47,14 +47,14 @@ func (c *Client) do(method, path string, input, output interface{}) error {
 
 	req, err := c.createRequest(method, url, input)
 	if err != nil {
-		return fmt.Errorf("Error creating request object: %s", err.Error())
+		return fmt.Errorf("error creating request object: %s", err.Error())
 	}
 
 	if err := c.executeRequest(req, output); err != nil {
 		if aerr, ok := err.(*errors.APIError); ok {
 			return aerr
 		}
-		return fmt.Errorf("Error executing request: %s", err.Error())
+		return fmt.Errorf("error executing request: %s", err.Error())
 	}
 
 	return nil
@@ -66,7 +66,7 @@ func (c *Client) doList(method, path string, input interface{}, outputCallback l
 	for {
 		req, err := c.createRequest(method, nextURL, input)
 		if err != nil {
-			return fmt.Errorf("Error creating request object: %s", err.Error())
+			return fmt.Errorf("error creating request object: %s", err.Error())
 		}
 
 		listOutput := &models.ListAPIOutput{}
@@ -74,12 +74,12 @@ func (c *Client) doList(method, path string, input interface{}, outputCallback l
 			if aerr, ok := err.(*errors.APIError); ok {
 				return aerr
 			}
-			return fmt.Errorf("Error executing request: %s", err.Error())
+			return fmt.Errorf("error executing request: %s", err.Error())
 		}
 
 		for _, v := range listOutput.Results {
 			if err := outputCallback(v); err != nil {
-				return fmt.Errorf("Error unmarshalling output item: %s", err.Error())
+				return fmt.Errorf("error unmarshalling output item: %s", err.Error())
 			}
 		}
 
@@ -127,7 +127,7 @@ func (c *Client) createRequest(method, url string, bodyObject interface{}) (req 
 	if bodyObject != nil {
 		data, err := json.Marshal(bodyObject)
 		if err != nil {
-			return nil, fmt.Errorf("Error marshaling body object: %s", err.Error())
+			return nil, fmt.Errorf("error marshaling body object: %s", err.Error())
 		}
 
 		reqBodyDebug = data
@@ -137,7 +137,7 @@ func (c *Client) createRequest(method, url string, bodyObject interface{}) (req 
 
 	req, err = http.NewRequest(method, url, reqBody)
 	if err != nil {
-		return nil, fmt.Errorf("Error creating HTTP request: %s", err.Error())
+		return nil, fmt.Errorf("error creating HTTP request: %s", err.Error())
 	}
 
 	req.Header.Set("Content-Type", "application/json")
@@ -167,13 +167,13 @@ func (c *Client) executeRequest(req *http.Request, output interface{}) (err erro
 
 	res, err := httpClient.Do(req)
 	if err != nil {
-		return fmt.Errorf("Error making HTTP request: %s", err.Error())
+		return fmt.Errorf("error making HTTP request: %s", err.Error())
 	}
 	defer res.Body.Close()
 
 	resData, err := ioutil.ReadAll(res.Body)
 	if err != nil {
-		return fmt.Errorf("Error reading response body data: %s", err.Error())
+		return fmt.Errorf("error reading response body data: %s", err.Error())
 	}
 
 	if c.logger != nil {
@@ -183,7 +183,7 @@ func (c *Client) executeRequest(req *http.Request, output interface{}) (err erro
 	if res.StatusCode >= 200 && res.StatusCode < 300 {
 		if output != nil && len(resData) > 0 {
 			if err := json.Unmarshal(resData, output); err != nil {
-				return fmt.Errorf("Error unmarshaling response data: %s", err.Error())
+				return fmt.Errorf("error unmarshaling response data: %s", err.Error())
 			}
 		}
 

--- a/client/customs.go
+++ b/client/customs.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"net/http"
 
-	"github.com/coldbrewcloud/go-shippo/models"
+	"github.com/courtyard-nft/go-shippo/models"
 )
 
 // CreateCustomsItem creates a new customs item object.
@@ -22,7 +22,7 @@ func (c *Client) CreateCustomsItem(input *models.CustomsItemInput) (*models.Cust
 // RetrieveCustomsItem retrieves an existing customs item by object id.
 func (c *Client) RetrieveCustomsItem(objectID string) (*models.CustomsItem, error) {
 	if objectID == "" {
-		return nil, errors.New("Empty object ID")
+		return nil, errors.New("empty object ID")
 	}
 
 	output := &models.CustomsItem{}
@@ -65,7 +65,7 @@ func (c *Client) CreateCustomsDeclaration(input *models.CustomsDeclarationInput)
 // RetrieveCustomsDeclaration retrieves an existing customs declaration by object id.
 func (c *Client) RetrieveCustomsDeclaration(objectID string) (*models.CustomsDeclaration, error) {
 	if objectID == "" {
-		return nil, errors.New("Empty object ID")
+		return nil, errors.New("empty object ID")
 	}
 
 	output := &models.CustomsDeclaration{}

--- a/client/manifest.go
+++ b/client/manifest.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"net/http"
 
-	"github.com/coldbrewcloud/go-shippo/models"
+	"github.com/courtyard-nft/go-shippo/models"
 )
 
 // CreateManifest creates a new manifest object.
@@ -22,7 +22,7 @@ func (c *Client) CreateManifest(input *models.ManifestInput) (*models.Manifest, 
 // RetrieveManifest retrieves an existing manifest by object id.
 func (c *Client) RetrieveManifest(objectID string) (*models.Manifest, error) {
 	if objectID == "" {
-		return nil, errors.New("Empty object ID")
+		return nil, errors.New("empty object ID")
 	}
 
 	output := &models.Manifest{}

--- a/client/parcel.go
+++ b/client/parcel.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"net/http"
 
-	"github.com/coldbrewcloud/go-shippo/models"
+	"github.com/courtyard-nft/go-shippo/models"
 )
 
 // CreateParcel creates a new parcel object.
@@ -22,7 +22,7 @@ func (c *Client) CreateParcel(input *models.ParcelInput) (*models.Parcel, error)
 // RetrieveParcel retrieves an existing parcel by object id.
 func (c *Client) RetrieveParcel(objectID string) (*models.Parcel, error) {
 	if objectID == "" {
-		return nil, errors.New("Empty object ID")
+		return nil, errors.New("empty object ID")
 	}
 
 	output := &models.Parcel{}

--- a/client/rate.go
+++ b/client/rate.go
@@ -5,16 +5,16 @@ import (
 	"errors"
 	"net/http"
 
-	"github.com/coldbrewcloud/go-shippo/models"
+	"github.com/courtyard-nft/go-shippo/models"
 )
 
 // GetShippingRates gets rates for a shipping object.
 func (c *Client) GetShippingRates(shipmentObjectID, currencyCode string) ([]*models.Rate, error) {
 	if shipmentObjectID == "" {
-		return nil, errors.New("Empty shipment object ID")
+		return nil, errors.New("empty shipment object ID")
 	}
 	if currencyCode == "" {
-		return nil, errors.New("Empty currency code")
+		return nil, errors.New("empty currency code")
 	}
 
 	list := []*models.Rate{}
@@ -33,7 +33,7 @@ func (c *Client) GetShippingRates(shipmentObjectID, currencyCode string) ([]*mod
 // RetrieveRate retrieves an existing rate by object id.
 func (c *Client) RetrieveRate(objectID string) (*models.Rate, error) {
 	if objectID == "" {
-		return nil, errors.New("Empty object ID")
+		return nil, errors.New("empty object ID")
 	}
 
 	output := &models.Rate{}

--- a/client/refund.go
+++ b/client/refund.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"net/http"
 
-	"github.com/coldbrewcloud/go-shippo/models"
+	"github.com/courtyard-nft/go-shippo/models"
 )
 
 // CreateRefund creates a new refund object.
@@ -22,7 +22,7 @@ func (c *Client) CreateRefund(input *models.RefundInput) (*models.Refund, error)
 // RetrieveRefund retrieves an existing refund by object id.
 func (c *Client) RetrieveRefund(objectID string) (*models.Refund, error) {
 	if objectID == "" {
-		return nil, errors.New("Empty object ID")
+		return nil, errors.New("empty object ID")
 	}
 
 	output := &models.Refund{}

--- a/client/shipment.go
+++ b/client/shipment.go
@@ -6,7 +6,7 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/coldbrewcloud/go-shippo/models"
+	"github.com/courtyard-nft/go-shippo/models"
 )
 
 // CreateShipment creates a new shipment object.
@@ -64,7 +64,7 @@ func (c *Client) CreateShipment(input *models.ShipmentInput) (*models.Shipment, 
 // RetrieveShipment retrieves an existing shipment by object id.
 func (c *Client) RetrieveShipment(objectID string) (*models.Shipment, error) {
 	if objectID == "" {
-		return nil, errors.New("Empty object ID")
+		return nil, errors.New("empty object ID")
 	}
 
 	output := &models.Shipment{}

--- a/client/tracking_status.go
+++ b/client/tracking_status.go
@@ -4,16 +4,16 @@ import (
 	"errors"
 	"net/http"
 
-	"github.com/coldbrewcloud/go-shippo/models"
+	"github.com/courtyard-nft/go-shippo/models"
 )
 
 // GetTrackingUpdate requests the tracking status of a shipment.
 func (c *Client) GetTrackingUpdate(carrier, trackingNumber string) (*models.TrackingStatus, error) {
 	if carrier == "" {
-		return nil, errors.New("Empty carrier")
+		return nil, errors.New("empty carrier")
 	}
 	if trackingNumber == "" {
-		return nil, errors.New("Empty tracking number")
+		return nil, errors.New("empty tracking number")
 	}
 
 	output := &models.TrackingStatus{}
@@ -26,10 +26,10 @@ func (c *Client) GetTrackingUpdate(carrier, trackingNumber string) (*models.Trac
 // https://goshippo.com/docs/reference#tracks-create
 func (c *Client) RegisterTrackingWebhook(carrier, trackingNumber, metadata string) (*models.TrackingStatus, error) {
 	if carrier == "" {
-		return nil, errors.New("Empty carrier")
+		return nil, errors.New("empty carrier")
 	}
 	if trackingNumber == "" {
-		return nil, errors.New("Empty tracking number")
+		return nil, errors.New("empty tracking number")
 	}
 
 	output := &models.TrackingStatus{}

--- a/client/transaction.go
+++ b/client/transaction.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"net/http"
 
-	"github.com/coldbrewcloud/go-shippo/models"
+	"github.com/courtyard-nft/go-shippo/models"
 )
 
 // PurchaseShippingLabel creates a new transaction object and purchases the shipping label for the provided rate.
@@ -22,7 +22,7 @@ func (c *Client) PurchaseShippingLabel(input *models.TransactionInput) (*models.
 // RetrieveTransaction retrieves an existing transaction by object id.
 func (c *Client) RetrieveTransaction(objectID string) (*models.Transaction, error) {
 	if objectID == "" {
-		return nil, errors.New("Empty object ID")
+		return nil, errors.New("empty object ID")
 	}
 
 	output := &models.Transaction{}

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,4 +1,4 @@
-package: github.com/coldbrewcloud/go-shippo
+package: github.com/courtyard-nft/go-shippo
 import:
 - package: github.com/stretchr/testify
   version: 976c720a22c8eb4eb6a0b4348ad85ad12491a506

--- a/models/parcel.go
+++ b/models/parcel.go
@@ -29,7 +29,7 @@ type ParcelCOD struct {
 type ParcelInsurance struct {
 	Amount   string `json:"amount"`
 	Currency string `json:"currency"`
-	Provider string `json:"provider"`
+	Provider string `json:"provider,omitempty"`
 	Content  string `json:"content"`
 }
 

--- a/models/shipment.go
+++ b/models/shipment.go
@@ -77,7 +77,7 @@ type ShipmentCOD struct {
 type ShipmentInsurance struct {
 	Amount   string `json:"amount"`
 	Currency string `json:"currency"`
-	Provider string `json:"provider"`
+	Provider string `json:"provider,omitempty"`
 	Content  string `json:"content"`
 }
 

--- a/shippo.go
+++ b/shippo.go
@@ -1,6 +1,6 @@
 package shippo
 
-import "github.com/coldbrewcloud/go-shippo/client"
+import "github.com/courtyard-nft/go-shippo/client"
 
 const (
 	APIVersion20140211 = "2014-02-11"


### PR DESCRIPTION
## Context
In order to select the default insurance option provided by Shippo, we cannot pass any value for the "provider" field. However, the "provider" field is not set as "omitempty" (which means it cannot be left empty), so if we try to pass an empty value for this field, Shippo's API receives an invalid Insurance object, causing the "invalid option" error to be returned. Therefore, it is not possible to use the default Shippo insurance option when the "provider" field is not set correctly.

## Solution
The Pull Request fixes this issue by adding the "omitempty" option to the "provider" field in the Insurance object. This option allows the field to be omitted if it has an empty value, which is what we want when using the default insurance option provided by Shippo. With this change, the Insurance object is correctly passed to Shippo's API, and the "invalid option" error is no longer returned. Therefore, by adding the "omitempty" option to the "provider" field, the Pull Request enables the use of the default Shippo insurance option.