### PR TITLE
Add json:omitempty for ParcelInsurance.Provider, ShipmentInsurance.Provider

### DIFF
--- a/models/parcel.go
+++ b/models/parcel.go
@@ -29,7 +29,7 @@ type ParcelCOD struct {
 type ParcelInsurance struct {
 	Amount   string `json:"amount"`
 	Currency string `json:"currency"`
-	Provider string `json:"provider"`
+	Provider string `json:"provider,omitempty"`
 	Content  string `json:"content"`
 }
 

--- a/models/shipment.go
+++ b/models/shipment.go
@@ -77,7 +77,7 @@ type ShipmentCOD struct {
 type ShipmentInsurance struct {
 	Amount   string `json:"amount"`
 	Currency string `json:"currency"`
-	Provider string `json:"provider"`
+	Provider string `json:"provider,omitempty"`
 	Content  string `json:"content"`
 }
 


### PR DESCRIPTION
Adds `omitempty` to `ParcelInsurance.Provider` and `ShipmentInsurance.Provider`, so that Shippo uses XCover if this field is omitted.

Without `omitempty`, omitting the `Provider` field causes Shippo to return an error that the `Provider` field is invalid.