### PR TITLE
Add `json:omitempty` for `TransactionInput.LabelFileType`

### DIFF
--- a/models/transaction.go
+++ b/models/transaction.go
@@ -6,7 +6,7 @@ import "time"
 type TransactionInput struct {
 	Rate          string `json:"rate,omitempty"`
 	Metadata      string `json:"metadata,omitempty"`
-	LabelFileType string `json:"label_file_type"`
+	LabelFileType string `json:"label_file_type,omitempty"`
 	Async         bool   `json:"async"`
 
 	Shipment         *ShipmentInput `json:"shipment,omitempty"`              // instant call only: https://goshippo.com/docs/reference#transactions-create-instant


### PR DESCRIPTION
Adds `omitempty` to the `TransactionInput.LabelFileType` field, so that Shippo uses the default label file type configured in the account settings.

Without `omitempty`, omitting the `LabelFileType` field causes Shippo to return an error that the `LabelFileType` is invalid.